### PR TITLE
Brighten UI palette

### DIFF
--- a/experience/index.html
+++ b/experience/index.html
@@ -13,14 +13,14 @@
   <style>
     body {
       font-family: 'Segoe UI', sans-serif;
-      background-color: #fdfbe9;
+      background-color: #fffbe7;
       color: #2e3d27;
       margin: 0;
       padding: 0;
     }
 
     header {
-      background-color: #a4c686;
+      background-color: #b7e278;
       color: white;
       text-align: center;
       padding: 1rem;
@@ -35,7 +35,7 @@
     }
 
     button {
-      background-color: #8fbf68;
+      background-color: #a3d46f;
       border: none;
       border-radius: 8px;
       color: white;
@@ -47,11 +47,11 @@
     }
 
     button:hover {
-      background-color: #7aad59;
+      background-color: #94c964;
     }
 
     .exit-button {
-      background-color: #cc3333;
+      background-color: #ff6666;
       position: fixed;
       bottom: 0;
       left: 0;
@@ -69,7 +69,7 @@
       padding: 0.5rem;
       margin-bottom: 1rem;
       border-radius: 6px;
-      border: 1px solid #ccc;
+      border: 1px solid #e0e0e0;
       font-size: 1rem;
     }
 
@@ -86,8 +86,8 @@
 
     #errorBanner {
       display: none;
-      background-color: #ffcccc;
-      color: #660000;
+      background-color: #ffb3b3;
+      color: #990000;
       padding: 1rem;
       border-radius: 8px;
       margin-top: 1rem;

--- a/experience/style.css
+++ b/experience/style.css
@@ -13,5 +13,5 @@ select {
 .info {
   margin-top: 20px;
   padding: 10px;
-  border: 1px solid #ccc;
+  border: 1px solid #e0e0e0;
 }


### PR DESCRIPTION
## Summary
- use brighter green and red tones in the HTML styles
- lighten info box border color

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844174e0344832d90bf07e2514a9fbc