### PR TITLE
Support GPX tracks for trails

### DIFF
--- a/data/sample_trails.json
+++ b/data/sample_trails.json
@@ -7,6 +7,7 @@
     "length_km": 4.5,
     "closest_city": "Tel Aviv",
     "image_url": "/experience/images/default-stridequest.jpg",
+    "gpx_file": "parq.gpx",
     "history": "Park Hayarkon was once a seasonal swamp before being transformed into Tel Aviv's largest green space.",
     "checkpoints": [
       {
@@ -99,6 +100,7 @@
     "length_km": 2.3,
     "closest_city": "Caesarea",
     "image_url": "/experience/images/caesarea.jpg",
+    "gpx_file": "trail2.gpx",
     "history": "This trail runs alongside an ancient Roman aqueduct that once supplied water to the city of Caesarea, built by Herod the Great.",
     "checkpoints": [
       {
@@ -191,6 +193,7 @@
     "length_km": 2.0,
     "closest_city": "Masada",
     "image_url": "/experience/images/yarkon.jpg",
+    "gpx_file": "trail3.gpx",
     "history": "The Snake Path is a historical ascent to Masada, where Jewish rebels made a final stand against Rome in 73 CE.",
     "checkpoints": [
       {
@@ -283,6 +286,7 @@
     "length_km": 3.1,
     "closest_city": "Tel Aviv",
     "image_url": "/experience/images/default-stridequest.jpg",
+    "gpx_file": "trail4.gpx",
     "history": "The Tel Aviv Port was once Israel's main gateway for maritime trade and is now a recreational hub with deep historical roots.",
     "checkpoints": [
       {

--- a/experience/script.js
+++ b/experience/script.js
@@ -263,7 +263,9 @@ function initMap(lat, lon) {
       L.marker([cp.lat, cp.lon]).addTo(map).bindPopup(cp.title)
     );
 
-    const points = currentTrail.checkpoints.map(cp => [cp.lat, cp.lon]);
+    const points = (currentTrail.gpx_points && currentTrail.gpx_points.length)
+      ? currentTrail.gpx_points.map(p => [p.lat, p.lon])
+      : currentTrail.checkpoints.map(cp => [cp.lat, cp.lon]);
     if (trailLine) trailLine.remove();
     trailLine = L.polyline(points, { color: 'blue' }).addTo(map);
   }

--- a/gpx/parq.gpx
+++ b/gpx/parq.gpx
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gpx version="1.1" creator="StrideQuest">
+  <trk>
+    <name>Park Hayarkon Trail</name>
+    <trkseg>
+      <trkpt lat="32.0965" lon="34.805"></trkpt>
+      <trkpt lat="32.097" lon="34.806"></trkpt>
+      <trkpt lat="32.0975" lon="34.807"></trkpt>
+      <trkpt lat="32.098" lon="34.808"></trkpt>
+      <trkpt lat="32.0985" lon="34.809"></trkpt>
+    </trkseg>
+  </trk>
+</gpx>

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ fastapi
 uvicorn
 pydantic
 folium
+gpxpy

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ setup(
         "uvicorn",
         "pydantic",
         "folium",
+        "gpxpy",
     ],
     entry_points={
         "console_scripts": [

--- a/utils/trail_finder.py
+++ b/utils/trail_finder.py
@@ -3,13 +3,51 @@ import copy
 import logging
 from pathlib import Path
 from geopy.distance import distance
+import gpxpy
 
 # Constants
 TRAILS_PATH = Path(__file__).resolve().parent.parent / "data" / "sample_trails.json"
+GPX_DIR = Path(__file__).resolve().parent.parent / "gpx"
 MAX_DIST = 200  # in km, must match frontend expectation
 
 # Setup logging
 logging.basicConfig(level=logging.INFO)
+
+def parse_gpx_file(filename):
+    """Parse a GPX file and return a list of points."""
+    path = GPX_DIR / filename
+    if not path.exists():
+        logging.warning(f"GPX file not found: {path}")
+        return []
+    try:
+        with path.open("r") as f:
+            gpx = gpxpy.parse(f)
+    except Exception as e:
+        logging.error(f"Failed to parse GPX file {path}: {e}")
+        return []
+
+    points = []
+    for track in gpx.tracks:
+        for segment in track.segments:
+            for p in segment.points:
+                points.append({"lat": p.latitude, "lon": p.longitude})
+    return points
+
+def assign_gpx_to_checkpoints(trail: dict) -> dict:
+    """Assign GPX coordinates to trail checkpoints if possible."""
+    if not trail.get("gpx_file") or not trail.get("checkpoints"):
+        return trail
+
+    gpx_points = parse_gpx_file(trail["gpx_file"])
+    if not gpx_points:
+        return trail
+
+    # Update checkpoint coordinates sequentially
+    for cp, pt in zip(trail["checkpoints"], gpx_points):
+        cp["lat"], cp["lon"] = pt["lat"], pt["lon"]
+
+    trail["gpx_points"] = gpx_points
+    return trail
 
 def validate_coordinates(lat, lon):
     return -90 <= lat <= 90 and -180 <= lon <= 180
@@ -39,6 +77,8 @@ def find_nearby_trails(user_lat, user_lon, radius_km=MAX_DIST):
         if dist_km <= radius_km:
             trail_copy = copy.deepcopy(trail)
             trail_copy["distance_km"] = round(dist_km, 2)
+            if trail_copy.get("gpx_file"):
+                trail_copy = assign_gpx_to_checkpoints(trail_copy)
             nearby.append(trail_copy)
 
     logging.info(f"User at ({user_lat}, {user_lon}) — Found {len(nearby)} nearby trails.")
@@ -58,6 +98,8 @@ def get_trail_by_id(trail_id: int):
 
     for trail in trails:
         if trail.get("id") == trail_id:
+            if trail.get("gpx_file"):
+                trail = assign_gpx_to_checkpoints(trail)
             return trail
 
     logging.warning(f"Trail with ID {trail_id} not found.")


### PR DESCRIPTION
## Summary
- add GPX parsing in `trail_finder`
- supply GPX filenames in sample trail data
- draw a GPX-based polyline if available
- depend on `gpxpy`
- remove placeholder GPX files

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6849a6fdde4c832d8b6506469df1d174