### PR TITLE
Enable retaking photos before submission

### DIFF
--- a/experience/index.html
+++ b/experience/index.html
@@ -115,9 +115,7 @@
 
     <div id="gameArea" style="display:none"></div>
 
-    <div id="photoArea" style="margin-top:2rem;">
-      <button onclick="takePhoto()">📸 Take Photo</button>
-    </div>
+    <div id="photoArea" style="margin-top:2rem;"></div>
 
     <button id="exitGame" class="exit-button" onclick="exitGame()">❌ Exit Game</button>
   </main>

--- a/experience/script.js
+++ b/experience/script.js
@@ -12,6 +12,7 @@ let currentCheckpoint = null;
 let watcherId = null;
 let map, userMarker, checkpointMarkers = [];
 let trailLine = null;
+let currentPhotoUrl = null;
 
 // ✅ Expose public functions so buttons can call them
 window.getLocation = getLocation;
@@ -22,6 +23,8 @@ window.skipToNextCheckpoint = skipToNextCheckpoint;
 window.checkAnswer = checkAnswer;
 window.nextCheckpoint = nextCheckpoint;
 window.takePhoto = takePhoto;
+window.retakePhoto = retakePhoto;
+window.submitPhoto = submitPhoto;
 
 function getLocation() {
   if (navigator.geolocation) {
@@ -105,6 +108,8 @@ function startHike(trailId) {
     document.getElementById('trailSelectArea').style.display = 'none';
     document.getElementById('exitGame').style.display = 'block';
     document.getElementById('gameArea').style.display = 'block';
+    document.getElementById('photoArea').innerHTML = '';
+    currentPhotoUrl = null;
   
     // 🚨 Clear previous content just in case
     document.getElementById('trailInfo').innerHTML = '';
@@ -155,6 +160,8 @@ function exitGame() {
       document.getElementById('trailSelectArea').style.display = 'none';
       document.getElementById('gameArea').style.display = 'none';
       document.getElementById('exitGame').style.display = 'none';
+      document.getElementById('photoArea').innerHTML = '';
+      currentPhotoUrl = null;
   
       // Clear game state
       document.getElementById('gameArea').innerHTML = '';
@@ -199,7 +206,6 @@ function checkAnswer(selected, correct) {
       <p>${result}</p>
       <p>${currentCheckpoint.challenge.prompt}</p>
       <button onclick="takePhoto()">📸 Take Photo</button>
-      <button onclick="nextCheckpoint()">➡️ Continue</button>
     `;
   } else {
     document.getElementById('checkpointArea').innerHTML = `
@@ -213,6 +219,8 @@ function nextCheckpoint() {
   currentCheckpointIndex++;
   if (currentCheckpointIndex >= currentTrail.checkpoints.length) {
     document.getElementById('checkpointArea').innerHTML = `<h3>🎉 Trail Complete!</h3>`;
+    document.getElementById('photoArea').innerHTML = '';
+    currentPhotoUrl = null;
     return;
   }
 
@@ -221,6 +229,8 @@ function nextCheckpoint() {
     <p><strong>Next checkpoint:</strong> ${cp.title}</p>
     <button onclick="skipToNextCheckpoint()">🚀 Skip to next (dev only)</button>
   `;
+  document.getElementById('photoArea').innerHTML = '';
+  currentPhotoUrl = null;
 
   watcherId = navigator.geolocation.watchPosition(pos => {
     const lat = pos.coords.latitude;
@@ -316,6 +326,7 @@ function takePhoto() {
   .then(res => res.json())
   .then(data => {
     if (data.photo_url) {
+      currentPhotoUrl = data.photo_url;
       displayPhoto(data.photo_url);
     } else {
       alert("Failed to take photo.");
@@ -331,5 +342,44 @@ function displayPhoto(photoUrl) {
   const photoArea = document.getElementById('photoArea');
   photoArea.innerHTML = `
     <img src="${photoUrl}" alt="Captured Photo" style="width:50%; border-radius:8px; margin-top:1rem;">
+    <div style="margin-top:1rem;">
+      <button onclick="retakePhoto()">🔄 Retake</button>
+      <button onclick="submitPhoto()">✅ Submit</button>
+    </div>
   `;
 }
+
+function retakePhoto() {
+  takePhoto();
+}
+
+function submitPhoto() {
+  if (!currentPhotoUrl || !currentCheckpoint?.challenge?.keyword) return;
+  fetch(currentPhotoUrl)
+    .then(res => res.blob())
+    .then(blob => {
+      const fd = new FormData();
+      fd.append('image', new File([blob], 'photo.jpg', { type: blob.type }));
+      fd.append('keyword', currentCheckpoint.challenge.keyword);
+      return fetch(`${BASE_URL}/challenges/validate`, {
+        method: 'POST',
+        body: fd
+      });
+    })
+    .then(res => res.json())
+    .then(data => {
+      const photoArea = document.getElementById('photoArea');
+      if (data.valid) {
+        photoArea.innerHTML += '<p>✅ Photo accepted!</p>';
+        document.getElementById('checkpointArea').innerHTML = `
+          <button onclick="nextCheckpoint()">➡️ Continue</button>
+        `;
+      } else {
+        photoArea.innerHTML += '<p>❌ Photo did not match. Try again.</p>';
+      }
+    })
+    .catch(err => {
+      console.error('Error submitting photo:', err);
+    });
+}
+

--- a/utils/photo_validator.py
+++ b/utils/photo_validator.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+import imghdr
+
+
+def validate_photo(image_path: str, keyword: str) -> bool:
+    """Simple placeholder validation for location photos.
+
+    Checks that the image exists, is a valid image type, and that the
+    filename contains the expected keyword. A real implementation would
+    use computer vision to analyze the scene.
+    """
+    path = Path(image_path)
+    if not path.exists():
+        return False
+    if imghdr.what(path) is None:
+        return False
+    return keyword.lower().replace(" ", "") in path.stem.lower()
+


### PR DESCRIPTION
## Summary
- allow clearing of previous photos when starting or exiting the hike
- add photo preview with retake and submit buttons
- clear any photo preview when moving to the next checkpoint
- implement simple photo validator used by `/challenges/validate`
- remove default *Take Photo* button from the HTML

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'cv2')*

------
https://chatgpt.com/codex/tasks/task_e_6852c64e6b34832db689f87fbd5eae05