### PR TITLE
Replace imghdr with Pillow

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ opencv-python
 numpy
 starlette
 anyio
+Pillow

--- a/utils/photo_validator.py
+++ b/utils/photo_validator.py
@@ -1,6 +1,7 @@
 from pathlib import Path
-import imghdr
 from typing import Optional
+
+from PIL import Image, UnidentifiedImageError
 
 import cv2
 
@@ -26,7 +27,10 @@ def validate_photo(image_path: str, keyword: str) -> bool:
     path = Path(image_path)
     if not path.exists():
         return False
-    if imghdr.what(path) is None:
+    try:
+        with Image.open(path) as img:
+            img.verify()
+    except (UnidentifiedImageError, OSError):
         return False
     return keyword.lower().replace(" ", "") in path.stem.lower()
 


### PR DESCRIPTION
## Summary
- replace deprecated `imghdr` usage with Pillow image verification
- include `Pillow` in requirements

## Testing
- `python -m py_compile utils/photo_validator.py`

------
https://chatgpt.com/codex/tasks/task_e_685453d829a4832da73f87963a54f0b9