### PR TITLE
Add skip option for photo challenges

### DIFF
--- a/experience/script.js
+++ b/experience/script.js
@@ -226,6 +226,7 @@ function checkAnswer(selected, correct) {
       <p>${result}</p>
       <p>${currentCheckpoint.challenge.prompt}</p>
       <button onclick="takePhoto()">📸 Take Photo</button>
+      <button onclick="nextCheckpoint()">➡️ Continue</button>
     `;
   } else {
     document.getElementById('checkpointArea').innerHTML = `
@@ -399,6 +400,7 @@ function displayPhoto(photoUrl) {
     <div style="margin-top:1rem;">
       <button onclick="retakePhoto()">🔄 Retake</button>
       <button onclick="submitPhoto()">✅ Submit</button>
+      <button onclick="nextCheckpoint()">➡️ Continue</button>
     </div>
   `;
 }


### PR DESCRIPTION
## Summary
- update checkpoint UI to show continue button for photo challenges
- allow skipping after taking photo

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6854693574a4832d97a2587ab9931d0d