### PR TITLE
Move more logic to Python

### DIFF
--- a/main.py
+++ b/main.py
@@ -3,7 +3,7 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import HTMLResponse
 from routes import quizzes, trails
-from routes import challenges
+from routes import challenges, progress
 from pathlib import Path
 import utils.photo_taker as photo_taker
 
@@ -28,6 +28,7 @@ app.mount("/experience", StaticFiles(directory=experience_dir, html=True), name=
 app.include_router(trails.router, prefix="/trails", tags=["Trails"])
 app.include_router(quizzes.router, prefix="/quizzes", tags=["Quizzes"])
 app.include_router(challenges.router, prefix="/challenges", tags=["Challenges"])
+app.include_router(progress.router, prefix="/progress", tags=["Progress"])
 
 # Automatic redirection to experience
 @app.get("/", include_in_schema=False)

--- a/routes/progress.py
+++ b/routes/progress.py
@@ -1,0 +1,30 @@
+from fastapi import APIRouter
+from pydantic import BaseModel
+from geopy.distance import distance
+from utils.trail_finder import get_trail_by_id
+
+router = APIRouter()
+
+class PositionData(BaseModel):
+    trail_id: int
+    checkpoint_index: int
+    latitude: float
+    longitude: float
+
+@router.post("/check")
+def check_position(data: PositionData):
+    trail = get_trail_by_id(data.trail_id)
+    if not trail:
+        return {"error": "Trail not found"}
+    if data.checkpoint_index >= len(trail.get("checkpoints", [])):
+        return {"error": "Invalid checkpoint"}
+
+    cp = trail["checkpoints"][data.checkpoint_index]
+    cp_lat = cp.get("lat")
+    cp_lon = cp.get("lon")
+    if cp_lat is None or cp_lon is None:
+        return {"error": "Checkpoint coordinates missing"}
+
+    dist_km = distance((data.latitude, data.longitude), (cp_lat, cp_lon)).km
+    reached = dist_km < 0.05
+    return {"reached": reached, "distance_km": round(dist_km, 3)}


### PR DESCRIPTION
## Summary
- add progress router for server-side distance checks
- include progress router in main app
- use new API from the frontend and remove JS distance helpers

## Testing
- `python -m py_compile main.py routes/*.py utils/*.py`


------
https://chatgpt.com/codex/tasks/task_e_6857cfedaf38832d9f0280ad1d477c8c